### PR TITLE
Check if expression.(not|and|or) is truthy before continuing

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,15 +5,15 @@ function booleanJSONVariables(expression, results) {
     if (results.indexOf(expression) === -1) {
       results.push(expression) }
     return results }
-  else if ('not' in expression) {
+  else if (expression.not) {
     return booleanJSONVariables(expression.not, results) }
-  else if ('and' in expression) {
+  else if (expression.and) {
     return expression.and
       .reduce(
         function(results, expression) {
           return booleanJSONVariables(expression, results) },
         results) }
-  else if ('or' in expression) {
+  else if (expression.or) {
     return expression.or
       .reduce(
         function(results, expression) {


### PR DESCRIPTION
This fixes an edge case where if you have something like this:

```javascript
{
     "and": undefined,
     "or": ["a", "b"]
}
```

it would throw an error (`Uncaught TypeError: Cannot read property 'reduce' of undefined`) since it was trying to do `undefined.reduce()`